### PR TITLE
Allow to define log directory group and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The directories (usually one, but can be multiple) where PostgreSQL's socket wil
 
 Control the state of the postgresql service and whether it should start at boot time.
 
+    postgresql_log_dir_group: "{{ postgresql_group }}"
+    postgresql_log_dir_mode: 0700
+
+Group and permissions of the `log_directory` defined in `postgresql_global_config_options`.
+
     postgresql_global_config_options:
       - option: unix_socket_directories
         value: '{{ postgresql_unix_socket_directories | join(",") }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,10 @@ postgresql_unix_socket_directories:
 postgresql_service_state: started
 postgresql_service_enabled: true
 
+# Group and permissions of the `log_directory` defined in `postgresql_global_config_options`
+postgresql_log_dir_group: "{{ postgresql_group }}"
+postgresql_log_dir_mode: 0700
+
 # Global configuration options that will be set in postgresql.conf.
 postgresql_global_config_options:
   - option: unix_socket_directories

--- a/tasks/initialize.yml
+++ b/tasks/initialize.yml
@@ -32,6 +32,6 @@
   file:
     path: "{{ postgresql_effective_log_dir }}"
     owner: "{{ postgresql_user }}"
-    group: "{{ postgresql_group }}"
+    group: "{{ postgresql_log_dir_group }}"
     state: directory
-    mode: 0700
+    mode: "{{ postgresql_log_dir_mode }}"


### PR DESCRIPTION
## Description
Sometimes (and this is our case) it's useful to be able to define on the `log_directory` different group and permissions than the current default values that are `postgres` for group, and `0700` for permissions. Regarding the group, note that it's already possible to define a different group, but we don't want to use the `postgresql_group` already existing fact because we only want to change the log directory group, not the group for all files used by postgres (data directory, socket, config files, ...).

## Tests
In our case, validate that another user belonging to the defined group is able to read the current postgres log file, and thanks to the `setgid` (`postgresql_log_dir_mode: 02750`), the new log files created in the log directory.